### PR TITLE
chore: update meta for ESLint 8 compatibility

### DIFF
--- a/src/ExhaustiveDeps.js
+++ b/src/ExhaustiveDeps.js
@@ -11,6 +11,7 @@
 
 export default {
   meta: {
+    hasSuggestions: true,
     type: 'suggestion',
     docs: {
       description: 'verifies the list of dependencies for Hooks like useEffect and similar',


### PR DESCRIPTION
(The title says it ally, really. It’s quite trivial.)